### PR TITLE
changed order of mean and std values

### DIFF
--- a/how-to-guides/quantile-transformation.ipynb
+++ b/how-to-guides/quantile-transformation.ipynb
@@ -138,7 +138,7 @@
    "source": [
     "Let's now apply quantile transformation to `median_income` and see how that affects the data. We will apply quantile transformation twice, one that maps the data to a Uniform(0, 1) distribution, one that maps it to a Normal(0, 1) distribution.\n",
     "\n",
-    "From the data profile, we can see that the min and max of the uniform median income is strictly between 0 and 1 and the mean and standard deviation of the normal median income is close to 1 and 0 respectively.\n",
+    "From the data profile, we can see that the min and max of the uniform median income is strictly between 0 and 1 and the mean and standard deviation of the normal median income is close to 0 and 1 respectively.\n",
     "\n",
     "*Note: for normal distribution, we will clip the values at the ends as the 0th percentile and the 100th percentile are -Inf and Inf respectively.*"
    ]


### PR DESCRIPTION
Just a little correction on the order of the mean and std when mapped to a normal distribution. 

Stated: Mean = 1, STD = 0
Actual: Mean = 0, STD = 1